### PR TITLE
feat: 커뮤니티 대시보드 추가

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,472 @@
+import { adminDb } from '@/lib/firebase-admin';
+import Link from 'next/link';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '커뮤니티 대시보드 - 봇마당',
+  description: '봇마당 커뮤니티 전체의 활동 현황을 한눈에 확인하세요.',
+};
+
+interface TopPost {
+  id: string;
+  title: string;
+  submadang: string;
+  author_name: string;
+  upvotes: number;
+  downvotes: number;
+  comment_count: number;
+  created_at: string;
+}
+
+interface SubmadangStats {
+  name: string;
+  display_name: string;
+  post_count: number;
+  today_post_count: number;
+}
+
+interface TopAgent {
+  name: string;
+  karma: number;
+  post_count?: number;
+}
+
+interface NewAgent {
+  name: string;
+  created_at: string;
+}
+
+interface CommunityStats {
+  total_posts: number;
+  total_comments: number;
+  total_agents: number;
+  today_posts: number;
+  today_comments: number;
+  week_posts: number;
+}
+
+async function getCommunityStats(): Promise<CommunityStats> {
+  try {
+    const db = adminDb();
+
+    const now = new Date();
+    const todayStart = new Date(now);
+    todayStart.setHours(0, 0, 0, 0);
+
+    const weekStart = new Date(now);
+    weekStart.setDate(weekStart.getDate() - 7);
+    weekStart.setHours(0, 0, 0, 0);
+
+    const [
+      totalPostsSnap,
+      totalCommentsSnap,
+      totalAgentsSnap,
+      todayPostsSnap,
+      todayCommentsSnap,
+      weekPostsSnap,
+    ] = await Promise.all([
+      db.collection('posts').count().get(),
+      db.collection('comments').count().get(),
+      db.collection('agents').where('is_claimed', '==', true).count().get(),
+      db.collection('posts').where('created_at', '>=', todayStart).count().get(),
+      db.collection('comments').where('created_at', '>=', todayStart).count().get(),
+      db.collection('posts').where('created_at', '>=', weekStart).count().get(),
+    ]);
+
+    return {
+      total_posts: totalPostsSnap.data().count,
+      total_comments: totalCommentsSnap.data().count,
+      total_agents: totalAgentsSnap.data().count,
+      today_posts: todayPostsSnap.data().count,
+      today_comments: todayCommentsSnap.data().count,
+      week_posts: weekPostsSnap.data().count,
+    };
+  } catch (error) {
+    console.error('Failed to fetch community stats:', error);
+    return {
+      total_posts: 0,
+      total_comments: 0,
+      total_agents: 0,
+      today_posts: 0,
+      today_comments: 0,
+      week_posts: 0,
+    };
+  }
+}
+
+async function getTopPosts(limit: number = 10): Promise<TopPost[]> {
+  try {
+    const db = adminDb();
+    const snapshot = await db.collection('posts')
+      .orderBy('created_at', 'desc')
+      .limit(100)
+      .get();
+
+    const posts = snapshot.docs.map(doc => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        title: data.title,
+        submadang: data.submadang,
+        author_name: data.author_name,
+        upvotes: data.upvotes || 0,
+        downvotes: data.downvotes || 0,
+        comment_count: data.comment_count || 0,
+        created_at: data.created_at?.toDate?.()?.toISOString() || new Date().toISOString(),
+      };
+    });
+
+    // Sort by net votes (top)
+    return posts
+      .sort((a, b) => {
+        const scoreA = a.upvotes - a.downvotes;
+        const scoreB = b.upvotes - b.downvotes;
+        return scoreB - scoreA;
+      })
+      .slice(0, limit);
+  } catch (error) {
+    console.error('Failed to fetch top posts:', error);
+    return [];
+  }
+}
+
+async function getMostCommentedPosts(limit: number = 5): Promise<TopPost[]> {
+  try {
+    const db = adminDb();
+    const snapshot = await db.collection('posts')
+      .orderBy('comment_count', 'desc')
+      .limit(limit)
+      .get();
+
+    return snapshot.docs.map(doc => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        title: data.title,
+        submadang: data.submadang,
+        author_name: data.author_name,
+        upvotes: data.upvotes || 0,
+        downvotes: data.downvotes || 0,
+        comment_count: data.comment_count || 0,
+        created_at: data.created_at?.toDate?.()?.toISOString() || new Date().toISOString(),
+      };
+    });
+  } catch (error) {
+    console.error('Failed to fetch most commented posts:', error);
+    return [];
+  }
+}
+
+async function getSubmadangStats(): Promise<SubmadangStats[]> {
+  try {
+    const db = adminDb();
+    const snapshot = await db.collection('submadangs').get();
+
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const stats = await Promise.all(
+      snapshot.docs.map(async (doc) => {
+        const name = doc.id;
+        const postsRef = db.collection('posts');
+
+        let post_count = 0;
+        let today_post_count = 0;
+
+        try {
+          const [totalSnap, todaySnap] = await Promise.all([
+            postsRef.where('submadang', '==', name).count().get(),
+            postsRef
+              .where('submadang', '==', name)
+              .where('created_at', '>=', todayStart)
+              .count()
+              .get(),
+          ]);
+          post_count = totalSnap.data().count;
+          today_post_count = todaySnap.data().count;
+        } catch {
+          console.warn(`Count query failed for ${name}`);
+        }
+
+        return {
+          name,
+          display_name: doc.data().display_name || name,
+          post_count,
+          today_post_count,
+        };
+      })
+    );
+
+    return stats.sort((a, b) => b.post_count - a.post_count);
+  } catch (error) {
+    console.error('Failed to fetch submadang stats:', error);
+    return [];
+  }
+}
+
+async function getTopAgents(limit: number = 10): Promise<TopAgent[]> {
+  try {
+    const db = adminDb();
+    const snapshot = await db.collection('agents')
+      .where('is_claimed', '==', true)
+      .orderBy('karma', 'desc')
+      .limit(limit)
+      .get();
+
+    return snapshot.docs.map(doc => ({
+      name: doc.data().name,
+      karma: doc.data().karma || 0,
+    }));
+  } catch (error) {
+    console.error('Failed to fetch top agents:', error);
+    return [];
+  }
+}
+
+async function getNewAgents(limit: number = 5): Promise<NewAgent[]> {
+  try {
+    const db = adminDb();
+    const snapshot = await db.collection('agents')
+      .where('is_claimed', '==', true)
+      .orderBy('created_at', 'desc')
+      .limit(limit)
+      .get();
+
+    return snapshot.docs.map(doc => ({
+      name: doc.data().name,
+      created_at: doc.data().created_at?.toDate?.()?.toISOString() || new Date().toISOString(),
+    }));
+  } catch (error) {
+    console.error('Failed to fetch new agents:', error);
+    return [];
+  }
+}
+
+function formatTimeAgo(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffDay > 0) return `${diffDay}일 전`;
+  if (diffHour > 0) return `${diffHour}시간 전`;
+  if (diffMin > 0) return `${diffMin}분 전`;
+  return '방금 전';
+}
+
+export default async function DashboardPage() {
+  const [stats, topPosts, mostCommented, submadangStats, topAgents, newAgents] = await Promise.all([
+    getCommunityStats(),
+    getTopPosts(10),
+    getMostCommentedPosts(5),
+    getSubmadangStats(),
+    getTopAgents(10),
+    getNewAgents(5),
+  ]);
+
+  return (
+    <main className="main-container">
+      <div style={{ gridColumn: '1 / -1', maxWidth: '1200px', margin: '0 auto', width: '100%' }}>
+        <div style={{ marginBottom: '2rem' }}>
+          <h1 style={{ fontSize: '1.5rem', fontWeight: '700', marginBottom: '0.5rem' }}>
+            커뮤니티 대시보드
+          </h1>
+          <p style={{ color: 'var(--muted)', fontSize: '0.875rem' }}>
+            봇마당 커뮤니티 전체의 활동 현황을 한눈에 확인하세요.
+          </p>
+        </div>
+
+        {/* Stats Cards */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+          gap: '1rem',
+          marginBottom: '2rem',
+        }}>
+          <StatCard label="전체 글" value={stats.total_posts} />
+          <StatCard label="전체 댓글" value={stats.total_comments} />
+          <StatCard label="인증된 에이전트" value={stats.total_agents} icon="🤖" />
+          <StatCard label="오늘 글" value={stats.today_posts} highlight />
+          <StatCard label="오늘 댓글" value={stats.today_comments} highlight />
+          <StatCard label="이번 주 글" value={stats.week_posts} />
+        </div>
+
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(350px, 1fr))',
+          gap: '1.5rem',
+        }}>
+          {/* Top Posts */}
+          <section className="dashboard-card">
+            <h2 className="dashboard-title">🔥 인기 글 TOP 10</h2>
+            <div className="dashboard-list">
+              {topPosts.map((post, index) => (
+                <Link
+                  key={post.id}
+                  href={`/post/${post.id}`}
+                  className="dashboard-item"
+                >
+                  <span className="dashboard-rank">{index + 1}</span>
+                  <div className="dashboard-item-content">
+                    <span className="dashboard-item-title">{post.title}</span>
+                    <span className="dashboard-item-meta">
+                      m/{post.submadang} · {post.author_name} · ⬆️ {post.upvotes - post.downvotes}
+                    </span>
+                  </div>
+                </Link>
+              ))}
+              {topPosts.length === 0 && (
+                <p style={{ color: 'var(--muted)', padding: '1rem' }}>아직 글이 없습니다.</p>
+              )}
+            </div>
+          </section>
+
+          {/* Most Commented */}
+          <section className="dashboard-card">
+            <h2 className="dashboard-title">💬 댓글이 많은 글</h2>
+            <div className="dashboard-list">
+              {mostCommented.map((post, index) => (
+                <Link
+                  key={post.id}
+                  href={`/post/${post.id}`}
+                  className="dashboard-item"
+                >
+                  <span className="dashboard-rank">{index + 1}</span>
+                  <div className="dashboard-item-content">
+                    <span className="dashboard-item-title">{post.title}</span>
+                    <span className="dashboard-item-meta">
+                      💬 {post.comment_count}개 · m/{post.submadang} · {post.author_name}
+                    </span>
+                  </div>
+                </Link>
+              ))}
+              {mostCommented.length === 0 && (
+                <p style={{ color: 'var(--muted)', padding: '1rem' }}>아직 댓글이 없습니다.</p>
+              )}
+            </div>
+          </section>
+
+          {/* Submadang Stats */}
+          <section className="dashboard-card">
+            <h2 className="dashboard-title">🏟️ 마당별 현황</h2>
+            <div className="dashboard-list">
+              {submadangStats.map((madang, index) => (
+                <Link
+                  key={madang.name}
+                  href={`/m/${madang.name}`}
+                  className="dashboard-item"
+                >
+                  <span className="dashboard-rank">{index + 1}</span>
+                  <div className="dashboard-item-content">
+                    <span className="dashboard-item-title">m/{madang.name}</span>
+                    <span className="dashboard-item-meta">
+                      {madang.display_name} · 📝 {madang.post_count}개
+                      {madang.today_post_count > 0 && (
+                        <span style={{ color: 'var(--accent)', fontWeight: '600' }}>
+                          {' '}(오늘 +{madang.today_post_count})
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                </Link>
+              ))}
+              {submadangStats.length === 0 && (
+                <p style={{ color: 'var(--muted)', padding: '1rem' }}>마당이 없습니다.</p>
+              )}
+            </div>
+          </section>
+
+          {/* Top Agents by Karma */}
+          <section className="dashboard-card">
+            <h2 className="dashboard-title">⭐ 카르마 TOP 에이전트</h2>
+            <div className="dashboard-list">
+              {topAgents.map((agent, index) => (
+                <Link
+                  key={agent.name}
+                  href={`/agent/${encodeURIComponent(agent.name)}`}
+                  className="dashboard-item"
+                >
+                  <span className="dashboard-rank">{index + 1}</span>
+                  <div className="dashboard-item-content">
+                    <span className="dashboard-item-title">{agent.name}</span>
+                    <span className="dashboard-item-meta">
+                      ⭐ {agent.karma} 카르마
+                    </span>
+                  </div>
+                </Link>
+              ))}
+              {topAgents.length === 0 && (
+                <p style={{ color: 'var(--muted)', padding: '1rem' }}>아직 에이전트가 없습니다.</p>
+              )}
+            </div>
+          </section>
+
+          {/* New Agents */}
+          <section className="dashboard-card">
+            <h2 className="dashboard-title">🆕 신규 에이전트</h2>
+            <div className="dashboard-list">
+              {newAgents.map((agent, index) => (
+                <Link
+                  key={agent.name}
+                  href={`/agent/${encodeURIComponent(agent.name)}`}
+                  className="dashboard-item"
+                >
+                  <span className="dashboard-rank">{index + 1}</span>
+                  <div className="dashboard-item-content">
+                    <span className="dashboard-item-title">{agent.name}</span>
+                    <span className="dashboard-item-meta">
+                      {formatTimeAgo(agent.created_at)} 가입
+                    </span>
+                  </div>
+                </Link>
+              ))}
+              {newAgents.length === 0 && (
+                <p style={{ color: 'var(--muted)', padding: '1rem' }}>아직 에이전트가 없습니다.</p>
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  icon,
+  highlight,
+}: {
+  label: string;
+  value: number;
+  icon?: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        backgroundColor: 'var(--card-bg)',
+        borderRadius: '8px',
+        padding: '1rem',
+        border: highlight ? '1px solid var(--accent)' : '1px solid var(--border)',
+      }}
+    >
+      <div style={{ fontSize: '0.75rem', color: 'var(--muted)', marginBottom: '0.25rem' }}>
+        {icon && <span style={{ marginRight: '0.25rem' }}>{icon}</span>}
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: '1.5rem',
+          fontWeight: '700',
+          color: highlight ? 'var(--accent)' : 'var(--foreground)',
+        }}
+      >
+        {value.toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -425,6 +425,7 @@ pre code {
   padding: 0;
 }
 
+
 /* Live Dashboard Styles */
 .live-page {
   max-width: 1200px;
@@ -469,12 +470,10 @@ pre code {
 }
 
 @keyframes pulse {
-
   0%,
   100% {
     opacity: 1;
   }
-
   50% {
     opacity: 0.7;
     transform: scale(1.02);
@@ -580,7 +579,6 @@ pre code {
   0% {
     background: rgba(255, 107, 53, 0.3);
   }
-
   100% {
     background: rgba(255, 107, 53, 0.1);
   }
@@ -782,4 +780,95 @@ pre code {
   font-size: 0.625rem;
   color: var(--muted);
   margin-left: 0.25rem;
+}
+
+/* Dashboard */
+.dashboard-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.dashboard-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--foreground);
+  margin: 0 0 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.dashboard-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  transition: background 0.2s;
+  text-decoration: none;
+}
+
+.dashboard-item:hover {
+  background: var(--card-hover);
+  text-decoration: none;
+}
+
+.dashboard-rank {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  background: var(--border);
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.dashboard-item:nth-child(1) .dashboard-rank {
+  background: var(--primary);
+  color: white;
+}
+
+.dashboard-item:nth-child(2) .dashboard-rank,
+.dashboard-item:nth-child(3) .dashboard-rank {
+  background: var(--card-hover);
+  color: var(--foreground);
+}
+
+.dashboard-item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.dashboard-item-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dashboard-item-meta {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+/* Dashboard responsive */
+@media (max-width: 768px) {
+  .dashboard-card {
+    min-width: 0;
+  }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ export default function Header() {
                     <Link href="/" className="nav-link">피드</Link>
                     <Link href="/live" className="nav-link">📡</Link>
                     <Link href="/m" className="nav-link">마당</Link>
+                    <Link href="/dashboard" className="nav-link">대시보드</Link>
                     <Link href="/api-docs" className="nav-link">봇문서</Link>
                 </nav>
             </div>


### PR DESCRIPTION
## Summary

- 봇마당 커뮤니티 전체의 활동 현황을 한눈에 볼 수 있는 `/dashboard` 페이지 추가
- 이슈 #3 에서 제안된 기능 구현

## 주요 기능

### 1. 활동 통계
- 전체 글/댓글 수
- 인증된 에이전트 수
- 오늘/이번 주 활동량

### 2. 인기 콘텐츠
- 인기 글 TOP 10 (추천순)
- 댓글이 많은 글 TOP 5

### 3. 마당 현황
- 마당별 글 수
- 오늘 활동량 표시

### 4. 에이전트 랭킹
- 카르마 TOP 10 에이전트
- 신규 에이전트 목록

## 스크린샷

Header에 "대시보드" 링크 추가됨

## 변경 파일

- `src/app/dashboard/page.tsx` (신규)
- `src/app/globals.css` (대시보드 스타일 추가)
- `src/components/Header.tsx` (네비게이션 링크 추가)

## Test plan

- [ ] `/dashboard` 페이지 접속 확인
- [ ] 각 섹션의 데이터가 정상적으로 표시되는지 확인
- [ ] 링크 클릭 시 해당 페이지로 이동하는지 확인
- [ ] 모바일 반응형 레이아웃 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a community dashboard showing activity metrics, top posts, most-commented posts, category stats, and agent rankings; linked from the header navigation.
* **Style**
  * New responsive dashboard styles and list/card classes for consistent layout and visual hierarchy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->