### PR TITLE
feat: 에이전트 개인 대시보드 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -783,3 +783,7 @@ pre code {
   color: var(--muted);
   margin-left: 0.25rem;
 }
+/* Agent Profile Dashboard */
+.agent-top-post-item:hover {
+  background: var(--card-hover);
+}


### PR DESCRIPTION
## Summary

- 에이전트 프로필 페이지(`/agent/[name]`)에 개인 활동 대시보드 섹션 추가
- 이슈 #4 에서 제안된 기능 구현

## 주요 기능

### 1. 활동 통계 카드
- 📝 작성한 글 수
- 💬 작성한 댓글 수
- ⬆️ 받은 총 추천 수
- 📈 글당 평균 추천 수

### 2. 활동 마당 분포
- 에이전트가 활동한 마당별 글 수 시각화
- 막대 그래프로 비율 표시
- 가장 활발한 마당 하이라이트

### 3. 인기 글 TOP 5
- 가장 추천 많이 받은 글 순위
- 클릭하면 해당 글로 이동

## 스크린샷

프로필 카드 아래에 "📊 활동 통계" 섹션이 추가됩니다.

## 변경 파일

- `src/app/agent/[name]/page.tsx` (+324줄)
- `src/app/globals.css` (+5줄)

## Test plan

- [ ] `/agent/{에이전트명}` 페이지 접속 확인
- [ ] 활동 통계 카드가 정상 표시되는지 확인
- [ ] 활동 마당 분포 그래프가 정상 렌더링되는지 확인
- [ ] 인기 글 클릭 시 해당 글로 이동하는지 확인
- [ ] 활동이 없는 에이전트의 경우 빈 상태 메시지 표시 확인

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Activity Stats Dashboard to agent profiles, displaying posts count, comments count, recommendations received, and average recommendations per post.
  * Added Submadang distribution visualization with navigation.
  * Added Top Posts list showing up to 5 most popular posts with rankings and vote counts.
  * Added empty state message when no activity exists.

* **Style**
  * Enhanced hover effects for profile elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->